### PR TITLE
Feat/2 전역 예외 처리 도입

### DIFF
--- a/src/main/java/com/aicodinator/backend/global/exception/CustomException.java
+++ b/src/main/java/com/aicodinator/backend/global/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.aicodinator.backend.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+  private final ErrorCode errorCode;
+
+  public CustomException(ErrorCode errorCode){
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/com/aicodinator/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/aicodinator/backend/global/exception/ErrorCode.java
@@ -1,0 +1,48 @@
+package com.aicodinator.backend.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+  /*
+   * 400 BAD_REQUEST: 잘못된 요청
+   */
+  BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+
+  /*
+   * 401 UNAUTHORIZED: 인증되지 않은 사용자의 요청
+   */
+  UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+  INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
+  TOKEN_ALREADY_LOGOUT(HttpStatus.UNAUTHORIZED, "이미 로그아웃된 토큰입니다."),
+  TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+  INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다."),
+  INCORRECT_CURRENT_PASSWORD(HttpStatus.UNAUTHORIZED, "현재 비밀번호가 일치하지 않습니다."),
+
+  /*
+   * 403 FORBIDDEN: 권한이 없는 사용자의 요청
+   */
+  FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+  /*
+   * 404 NOT_FOUND: 리소스를 찾을 수 없음
+   */
+  NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 리소스를 찾을 수 없습니다."),
+
+  /*
+   * 405 METHOD_NOT_ALLOWED: 허용되지 않은 Request Method 호출
+   */
+  METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 요청 방식입니다."),
+
+  /*
+   * 500 INTERNAL_SERVER_ERROR: 내부 서버 오류
+   */
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+
+
+  private final HttpStatus httpStatus;
+  private final String message;
+}

--- a/src/main/java/com/aicodinator/backend/global/exception/ErrorResponse.java
+++ b/src/main/java/com/aicodinator/backend/global/exception/ErrorResponse.java
@@ -1,0 +1,13 @@
+package com.aicodinator.backend.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ErrorResponse {
+  private ErrorCode errorCode;
+  private String errorMessage;
+}

--- a/src/main/java/com/aicodinator/backend/global/exception/ValidErrorResponse.java
+++ b/src/main/java/com/aicodinator/backend/global/exception/ValidErrorResponse.java
@@ -1,0 +1,19 @@
+package com.aicodinator.backend.global.exception;
+
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ValidErrorResponse {
+  private final String errorCode;
+  private final String errorMessage;
+  private final Map<String, String> validation;
+
+  public void addValidation(String field, String message) {
+    this.validation.put(field, message);
+  }
+}

--- a/src/main/java/com/aicodinator/backend/global/exception/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/aicodinator/backend/global/exception/controller/GlobalExceptionHandler.java
@@ -1,0 +1,73 @@
+package com.aicodinator.backend.global.exception.controller;
+
+import com.aicodinator.backend.global.exception.CustomException;
+import com.aicodinator.backend.global.exception.ErrorCode;
+import com.aicodinator.backend.global.exception.ErrorResponse;
+import com.aicodinator.backend.global.exception.ValidErrorResponse;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@RequiredArgsConstructor
+@Slf4j
+public class GlobalExceptionHandler {
+  /**
+   * Validation 예외 처리
+   */
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ValidErrorResponse> handleValidationException(MethodArgumentNotValidException e){
+    log.error("ValidationException 발생: {}", e.getMessage(), e);
+
+    Map<String, String> validation = new HashMap<>();
+    for(FieldError fieldError : e.getFieldErrors()){
+      validation.put(fieldError.getField(), fieldError.getDefaultMessage());
+    }
+
+    ValidErrorResponse response = ValidErrorResponse.builder()
+        .errorCode(HttpStatus.BAD_REQUEST.toString())
+        .errorMessage("잘못된 요청입니다.")
+        .validation(validation)
+        .build();
+
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+  }
+
+  /**
+   * 커스텀 (비지니스) 예외 처리
+   */
+  @ExceptionHandler(CustomException.class)
+  public ResponseEntity<ErrorResponse> handleCustomException(CustomException e){
+    log.error("Custom Exception 발생: {}", e.getMessage(), e);
+
+    ErrorCode errorCode = e.getErrorCode();
+    ErrorResponse response = ErrorResponse.builder()
+        .errorCode(errorCode)
+        .errorMessage(errorCode.getMessage())
+        .build();
+
+    return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
+  }
+
+  /**
+   * 그 외 서버 (500) 예외 처리
+   */
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleException(Exception e){
+    log.error("Unhandled Exception 발생: {}", e.getMessage(), e);
+
+    ErrorResponse response = ErrorResponse.builder()
+        .errorCode(ErrorCode.INTERNAL_SERVER_ERROR)
+        .errorMessage(ErrorCode.INTERNAL_SERVER_ERROR.getMessage())
+        .build();
+
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+  }
+}


### PR DESCRIPTION
## ✨ 변경 사항
- 공통 에러 응답(ErrorResponse, ValidErrorResponse) 정의
- 기본 ErrorCode 정의
- 커스텀 예외(CustomException) 정의
- @RestControllerAdvice를 사용한 예외 핸들러 구현 (비즈니스, 유효성 검사, 서버 오류)
- 예외 응답 테스트

## 🔄 연관 이슈
- #2 

## ✅ 체크리스트
- [x] 코드 빌드/테스트 통과
- [x] 문서·주석 업데이트

## 📖 기타

