### PR TITLE
Feat/6 지역별 커뮤니티 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.3'
+	id 'org.springframework.boot' version '3.3.4'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -38,6 +38,14 @@ dependencies {
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
+    // MapStruct
+    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+
+    // s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/aicodinator/backend/domain/community/controller/BoardController.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/controller/BoardController.java
@@ -1,13 +1,11 @@
 package com.aicodinator.backend.domain.community.controller;
 
+import com.aicodinator.backend.domain.community.domain.dto.response.BoardResponse;
 import com.aicodinator.backend.domain.community.domain.entity.Board;
 import com.aicodinator.backend.domain.community.service.BoardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -15,17 +13,25 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api")
 public class BoardController {
-    private BoardService boardService;
+    private final BoardService boardService;
 
     /*@GetMapping
-    public List<Board> findMyBoards(@AuthenticationPrincipal User user) {
-        return boardService.findByUser(user);
+    public List<Board> findMyBoards(@AuthenticationPrincipal CustomOAuth2User oAuth2User) {
+        return boardService.findByUser(oAuth2User.getUser());
     }*/
 
     @GetMapping("/regions/{regionId}/boards")
-    public ResponseEntity<List<Board>> findBoardsByRegion(@PathVariable Long regionId) {
+    public ResponseEntity<List<BoardResponse>> findBoardsByRegion(@PathVariable Long regionId) {
         return ResponseEntity.ok(boardService.findByRegionId(regionId));
     }
 
-    // TODO: CustomOAuth2UserPrincipal로 변경
+    /**
+     * 테스트를 위한 API
+     * 실제로 Board 생성은 리포트 생성 시점에 서비스 로직에서 진행
+     */
+    @PostMapping("/regions/{regionId}/boards")
+    public ResponseEntity<Void> createBoardsByRegion(@PathVariable Long regionId) {
+        boardService.createBoards(regionId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/aicodinator/backend/domain/community/controller/BoardController.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/controller/BoardController.java
@@ -1,4 +1,31 @@
 package com.aicodinator.backend.domain.community.controller;
 
+import com.aicodinator.backend.domain.community.domain.entity.Board;
+import com.aicodinator.backend.domain.community.service.BoardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
 public class BoardController {
+    private BoardService boardService;
+
+    /*@GetMapping
+    public List<Board> findMyBoards(@AuthenticationPrincipal User user) {
+        return boardService.findByUser(user);
+    }*/
+
+    @GetMapping("/regions/{regionId}/boards")
+    public ResponseEntity<List<Board>> findBoardsByRegion(@PathVariable Long regionId) {
+        return ResponseEntity.ok(boardService.findByRegionId(regionId));
+    }
+
+    // TODO: CustomOAuth2UserPrincipal로 변경
 }

--- a/src/main/java/com/aicodinator/backend/domain/community/controller/CommentController.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/controller/CommentController.java
@@ -1,4 +1,46 @@
 package com.aicodinator.backend.domain.community.controller;
 
+import com.aicodinator.backend.domain.community.domain.dto.request.CommentEditRequest;
+import com.aicodinator.backend.domain.community.domain.dto.request.CommentRequest;
+import com.aicodinator.backend.domain.community.domain.dto.response.CommentResponse;
+import com.aicodinator.backend.domain.community.service.CommentService;
+import com.aicodinator.backend.domain.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
 public class CommentController {
+    private final CommentService commentService;
+
+    @GetMapping("/posts/{postId}/comments")
+    public ResponseEntity<List<CommentResponse>> getComments(@PathVariable Long postId) {
+        return ResponseEntity.ok(commentService.getCommentsByPostId(postId));
+    }
+
+    @PostMapping("/comments")
+    public ResponseEntity<CommentResponse> createComment(@RequestBody CommentRequest request, @AuthenticationPrincipal User user) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(commentService.createComment(request,user));
+    }
+
+    @PutMapping("/comments/{commentId}")
+    public ResponseEntity<CommentResponse> updateComment(@PathVariable Long commentId,
+                                              @RequestBody CommentEditRequest request,
+                                              @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(commentService.updateComment(commentId, request, user));
+    }
+
+    @DeleteMapping("comments/{commentId}")
+    public ResponseEntity<Void> deleteComment(@PathVariable Long commentId, @AuthenticationPrincipal User user) {
+        commentService.deleteComment(commentId, user);
+        return ResponseEntity.noContent().build();
+    }
+
+    // TODO: CustomOAuth2UserPrincipal로 변경
 }

--- a/src/main/java/com/aicodinator/backend/domain/community/controller/CommentController.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/controller/CommentController.java
@@ -4,7 +4,7 @@ import com.aicodinator.backend.domain.community.domain.dto.request.CommentEditRe
 import com.aicodinator.backend.domain.community.domain.dto.request.CommentRequest;
 import com.aicodinator.backend.domain.community.domain.dto.response.CommentResponse;
 import com.aicodinator.backend.domain.community.service.CommentService;
-import com.aicodinator.backend.domain.user.domain.entity.User;
+import com.aicodinator.backend.global.security.CustomOAuth2User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,27 +20,25 @@ public class CommentController {
     private final CommentService commentService;
 
     @GetMapping("/posts/{postId}/comments")
-    public ResponseEntity<List<CommentResponse>> getComments(@PathVariable Long postId) {
-        return ResponseEntity.ok(commentService.getCommentsByPostId(postId));
+    public ResponseEntity<List<CommentResponse>> getComments(@PathVariable Long postId, @AuthenticationPrincipal CustomOAuth2User oAuth2User) {
+        return ResponseEntity.ok(commentService.getCommentsByPostId(postId, oAuth2User.getUser()));
     }
 
     @PostMapping("/comments")
-    public ResponseEntity<CommentResponse> createComment(@RequestBody CommentRequest request, @AuthenticationPrincipal User user) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(commentService.createComment(request,user));
+    public ResponseEntity<CommentResponse> createComment(@RequestBody CommentRequest request, @AuthenticationPrincipal CustomOAuth2User oAuth2User) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(commentService.createComment(request, oAuth2User.getUser()));
     }
 
     @PutMapping("/comments/{commentId}")
     public ResponseEntity<CommentResponse> updateComment(@PathVariable Long commentId,
                                               @RequestBody CommentEditRequest request,
-                                              @AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(commentService.updateComment(commentId, request, user));
+                                              @AuthenticationPrincipal CustomOAuth2User oAuth2User) {
+        return ResponseEntity.ok(commentService.updateComment(commentId, request, oAuth2User.getUser()));
     }
 
     @DeleteMapping("comments/{commentId}")
-    public ResponseEntity<Void> deleteComment(@PathVariable Long commentId, @AuthenticationPrincipal User user) {
-        commentService.deleteComment(commentId, user);
+    public ResponseEntity<Void> deleteComment(@PathVariable Long commentId, @AuthenticationPrincipal CustomOAuth2User oAuth2User) {
+        commentService.deleteComment(commentId, oAuth2User.getUser());
         return ResponseEntity.noContent().build();
     }
-
-    // TODO: CustomOAuth2UserPrincipal로 변경
 }

--- a/src/main/java/com/aicodinator/backend/domain/community/controller/PostController.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/controller/PostController.java
@@ -1,4 +1,111 @@
 package com.aicodinator.backend.domain.community.controller;
 
+import com.aicodinator.backend.domain.community.domain.dto.request.PostEditRequest;
+import com.aicodinator.backend.domain.community.domain.dto.request.PostRequest;
+import com.aicodinator.backend.domain.community.domain.dto.response.MainPageResponse;
+import com.aicodinator.backend.domain.community.domain.dto.response.PostDetailResponse;
+import com.aicodinator.backend.domain.community.domain.dto.response.PostListResponse;
+import com.aicodinator.backend.domain.community.service.PostService;
+import com.aicodinator.backend.domain.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
 public class PostController {
+    private PostService postService;
+
+    /**
+     * 메인 페이지 게시글 목록 조회
+     */
+    @GetMapping("/main/posts")
+    public ResponseEntity<MainPageResponse> getMainPagePosts(@RequestParam("regionId") Long regionId) {
+        return ResponseEntity.ok(postService.getMainPagePosts(regionId));
+    }
+
+    /**
+     * 특정 게시판의 게시글 목록 페이징 조회
+     */
+    @GetMapping("/boards/{boardId}/posts")
+    public ResponseEntity<Page<PostListResponse>> getPostList(@PathVariable Long boardId,
+                                                              @RequestParam(defaultValue = "0") int page,
+                                                              @RequestParam(defaultValue = "10") int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return ResponseEntity.ok(postService.getPostList(boardId, pageable));
+    }
+
+    /**
+     * 게시글 상세 조회
+     */
+    @GetMapping("/posts/{postId}")
+    public ResponseEntity<PostDetailResponse> getPostDetail(@PathVariable Long postId, @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(postService.getPostDetail(postId, user));
+    }
+
+    /**
+     * 게시글 작성
+     */
+    @PostMapping(value = "/posts", consumes = {"multipart/form-data"})
+    public ResponseEntity<PostDetailResponse> createPost(@RequestPart("request") PostRequest request,
+                                                         @RequestPart(value = "files", required = false) List<MultipartFile> files,
+                                                         @AuthenticationPrincipal User user) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(postService.createPost(request, files, user));
+    }
+
+    /**
+     * 게시글 수정
+     */
+    @PatchMapping(value = "/posts/{postId}", consumes = {"multipart/form-data"})
+    public ResponseEntity<PostDetailResponse> updatePost(@PathVariable Long postId,
+                                                         @RequestPart("request") PostEditRequest request,
+                                                         @RequestPart(value = "newFiles", required = false) List<MultipartFile> newFiles,
+                                                         @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(postService.updatePost(postId, request, newFiles, user));
+    }
+
+    /**
+     * 게시글 삭제
+     */
+    @DeleteMapping("/posts/{postId}")
+    public ResponseEntity<Void> deletePost(@PathVariable Long postId, @AuthenticationPrincipal User user) {
+        postService.deletePost(postId, user);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 게시글 좋아요 여부 조회
+     */
+    @GetMapping("/posts/{postId}/likes")
+    public ResponseEntity<Boolean> checkLiked(@PathVariable Long postId, @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(postService.isLikedPost(postId, user));
+    }
+
+    /**
+     * 게시글 좋아요
+     */
+    @PostMapping("/posts/{postId}/likes")
+    public ResponseEntity<Boolean> like(@PathVariable Long postId, @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(postService.likePost(postId, user));
+    }
+
+    /**
+     * 게시글 좋아요 취소
+     */
+    @DeleteMapping("/posts/{postId}/likes")
+    public ResponseEntity<Boolean> unlike(@PathVariable Long postId, @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(postService.unlikePost(postId, user));
+    }
+
+    // TODO: CustomOAuth2UserPrincipal로 변경
 }

--- a/src/main/java/com/aicodinator/backend/domain/community/controller/PostController.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/controller/PostController.java
@@ -6,13 +6,17 @@ import com.aicodinator.backend.domain.community.domain.dto.response.MainPageResp
 import com.aicodinator.backend.domain.community.domain.dto.response.PostDetailResponse;
 import com.aicodinator.backend.domain.community.domain.dto.response.PostListResponse;
 import com.aicodinator.backend.domain.community.service.PostService;
-import com.aicodinator.backend.domain.user.domain.entity.User;
+import com.aicodinator.backend.global.security.CustomOAuth2User;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -24,7 +28,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api")
 public class PostController {
-    private PostService postService;
+    private final PostService postService;
 
     /**
      * 메인 페이지 게시글 목록 조회
@@ -49,18 +53,21 @@ public class PostController {
      * 게시글 상세 조회
      */
     @GetMapping("/posts/{postId}")
-    public ResponseEntity<PostDetailResponse> getPostDetail(@PathVariable Long postId, @AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(postService.getPostDetail(postId, user));
+    public ResponseEntity<PostDetailResponse> getPostDetail(@PathVariable Long postId, @AuthenticationPrincipal CustomOAuth2User oAuth2User) {
+        return ResponseEntity.ok(postService.getPostDetail(postId, oAuth2User.getUser()));
     }
 
     /**
      * 게시글 작성
      */
     @PostMapping(value = "/posts", consumes = {"multipart/form-data"})
-    public ResponseEntity<PostDetailResponse> createPost(@RequestPart("request") PostRequest request,
+    public ResponseEntity<PostDetailResponse> createPost(@Parameter(description = "게시글 생성 DTO", required = true,
+                                                                 content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                                                 schema = @Schema(implementation = PostRequest.class)))
+                                                         @RequestPart("request") PostRequest request,
                                                          @RequestPart(value = "files", required = false) List<MultipartFile> files,
-                                                         @AuthenticationPrincipal User user) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(postService.createPost(request, files, user));
+                                                         @AuthenticationPrincipal CustomOAuth2User oAuth2User) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(postService.createPost(request, files, oAuth2User.getUser()));
     }
 
     /**
@@ -68,18 +75,21 @@ public class PostController {
      */
     @PatchMapping(value = "/posts/{postId}", consumes = {"multipart/form-data"})
     public ResponseEntity<PostDetailResponse> updatePost(@PathVariable Long postId,
+                                                         @Parameter(description = "게시글 수정 DTO", required = true,
+                                                             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                                             schema = @Schema(implementation = PostEditRequest.class)))
                                                          @RequestPart("request") PostEditRequest request,
                                                          @RequestPart(value = "newFiles", required = false) List<MultipartFile> newFiles,
-                                                         @AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(postService.updatePost(postId, request, newFiles, user));
+                                                         @AuthenticationPrincipal CustomOAuth2User oAuth2User) {
+        return ResponseEntity.ok(postService.updatePost(postId, request, newFiles, oAuth2User.getUser()));
     }
 
     /**
      * 게시글 삭제
      */
     @DeleteMapping("/posts/{postId}")
-    public ResponseEntity<Void> deletePost(@PathVariable Long postId, @AuthenticationPrincipal User user) {
-        postService.deletePost(postId, user);
+    public ResponseEntity<Void> deletePost(@PathVariable Long postId, @AuthenticationPrincipal CustomOAuth2User oAuth2User) {
+        postService.deletePost(postId, oAuth2User.getUser());
         return ResponseEntity.noContent().build();
     }
 
@@ -87,25 +97,23 @@ public class PostController {
      * 게시글 좋아요 여부 조회
      */
     @GetMapping("/posts/{postId}/likes")
-    public ResponseEntity<Boolean> checkLiked(@PathVariable Long postId, @AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(postService.isLikedPost(postId, user));
+    public ResponseEntity<Boolean> checkLiked(@PathVariable Long postId, @AuthenticationPrincipal CustomOAuth2User oAuth2User) {
+        return ResponseEntity.ok(postService.isLikedPost(postId, oAuth2User.getUser()));
     }
 
     /**
      * 게시글 좋아요
      */
     @PostMapping("/posts/{postId}/likes")
-    public ResponseEntity<Boolean> like(@PathVariable Long postId, @AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(postService.likePost(postId, user));
+    public ResponseEntity<Boolean> like(@PathVariable Long postId, @AuthenticationPrincipal CustomOAuth2User oAuth2User) {
+        return ResponseEntity.ok(postService.likePost(postId, oAuth2User.getUser()));
     }
 
     /**
      * 게시글 좋아요 취소
      */
     @DeleteMapping("/posts/{postId}/likes")
-    public ResponseEntity<Boolean> unlike(@PathVariable Long postId, @AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(postService.unlikePost(postId, user));
+    public ResponseEntity<Boolean> unlike(@PathVariable Long postId, @AuthenticationPrincipal CustomOAuth2User oAuth2User) {
+        return ResponseEntity.ok(postService.unlikePost(postId, oAuth2User.getUser()));
     }
-
-    // TODO: CustomOAuth2UserPrincipal로 변경
 }

--- a/src/main/java/com/aicodinator/backend/domain/community/domain/constant/FileExtension.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/domain/constant/FileExtension.java
@@ -1,0 +1,66 @@
+package com.aicodinator.backend.domain.community.domain.constant;
+
+import com.aicodinator.backend.global.exception.CustomException;
+import com.aicodinator.backend.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+
+/**
+ * 허용되는 파일 확장자 및 관련 정보를 관리하는 Enum
+ */
+@Getter
+@RequiredArgsConstructor
+public enum FileExtension {
+    // 이미지 파일
+    JPG("jpg", "image/jpeg"),
+    JPEG("jpeg", "image/jpeg"),
+    PNG("png", "image/png"),
+
+    // 엑셀 파일
+    XLSX("xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+    XLS("xls", "application/vnd.ms-excel"),
+    CSV("csv", "text/csv"),
+
+    // 웹 게시 파일
+    PDF("pdf", "application/pdf"),
+    HTML("html", "text/html"),
+
+    // 문서 파일
+    HWP("hwp", "application/vnd.hancom.hwp"), // 또는 "application/x-hwp"
+    DOCX("docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+    DOC("doc", "application/msword"),
+    TXT("txt", "text/plain"),
+
+    // 프레젠테이션 파일
+    PPTX("pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation"),
+    PPT("ppt", "application/vnd.ms-powerpoint"),
+
+    // 압축 파일
+    ZIP("zip", "application/zip"),
+    TAR("tar", "application/x-tar");
+
+    private final String extension;
+    private final String contentType;
+
+    /**
+     * 파일명으로부터 확장자 추출 후 해당하는 FileExtension Enum 반환
+     * @param fileName 원본 파일명
+     * @return FileExtension Enum 객체
+     */
+    public static FileExtension fromFileName(String fileName) {
+        // 파일명에서 확장자 추출
+        String extension = StringUtils.getFilenameExtension(fileName);
+        if (extension == null) {
+            throw new CustomException(ErrorCode.INVALID_FILE_REQUEST, "요청하신 파일의 확장자가 존재하지 않습니다.");
+        }
+
+        // 추출된 확장자와 일치하는 Enum 반환
+        return Arrays.stream(values())
+            .filter(fileExtension -> fileExtension.getExtension().equals(extension.toLowerCase()))
+            .findFirst()
+            .orElseThrow(() -> new CustomException(ErrorCode.INVALID_FILE_REQUEST, "허용하지 않는 파일 확장자입니다. :" + extension));
+    }
+}

--- a/src/main/java/com/aicodinator/backend/domain/community/domain/constant/UploadType.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/domain/constant/UploadType.java
@@ -1,0 +1,6 @@
+package com.aicodinator.backend.domain.community.domain.constant;
+
+public enum UploadType {
+    REPORT,
+    COMMUNITY_POST
+}

--- a/src/main/java/com/aicodinator/backend/domain/community/domain/dto/request/CommentEditRequest.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/domain/dto/request/CommentEditRequest.java
@@ -1,0 +1,14 @@
+package com.aicodinator.backend.domain.community.domain.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentEditRequest {
+    @NotBlank(message = "댓글 내용은 필수입니다.")
+    private String content;
+}

--- a/src/main/java/com/aicodinator/backend/domain/community/domain/dto/request/CommentRequest.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/domain/dto/request/CommentRequest.java
@@ -1,0 +1,22 @@
+package com.aicodinator.backend.domain.community.domain.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class CommentRequest {
+    @NotNull(message = "게시글 Id는 필수입니다.")
+    private Long postId;
+
+    @NotBlank(message = "댓글 내용은 필수입니다.")
+    @Size(max = 100, message = "댓글은 100자 이하로 작성해주세요.")
+    private String content;
+}

--- a/src/main/java/com/aicodinator/backend/domain/community/domain/dto/request/PostEditRequest.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/domain/dto/request/PostEditRequest.java
@@ -1,0 +1,26 @@
+package com.aicodinator.backend.domain.community.domain.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class PostEditRequest {
+    @NotBlank(message = "게시글 제목은 필수입니다.")
+    @Size(max = 255, message = "제목은 255자 이내로 입력해주세요.")
+    private String title;
+
+    @Size(max = 1000, message = "게시글 내용은 1000자 이내로 작성해주세요.")
+    private String content;
+
+    private List<Long> deleteFileIds;
+}

--- a/src/main/java/com/aicodinator/backend/domain/community/domain/dto/request/PostRequest.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/domain/dto/request/PostRequest.java
@@ -1,0 +1,25 @@
+package com.aicodinator.backend.domain.community.domain.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class PostRequest {
+    @NotNull(message = "게시판 Id는 필수입니다.")
+    private Long boardId;
+
+    @NotBlank(message = "게시글 제목은 필수입니다.")
+    @Size(max = 255, message = "제목은 255자 이내로 입력해주세요.")
+    private String title;
+
+    @Size(max = 1000, message = "게시글 내용은 1000자 이내로 작성해주세요.")
+    private String content;
+}

--- a/src/main/java/com/aicodinator/backend/domain/community/domain/dto/response/BoardResponse.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/domain/dto/response/BoardResponse.java
@@ -1,0 +1,21 @@
+package com.aicodinator.backend.domain.community.domain.dto.response;
+
+import com.aicodinator.backend.domain.community.domain.constant.BoardType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class BoardResponse {
+    private Long boardId;
+
+    private Long regionId;
+
+    private String regionName;
+
+    private BoardType boardType;
+}

--- a/src/main/java/com/aicodinator/backend/domain/community/domain/dto/response/CommentResponse.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/domain/dto/response/CommentResponse.java
@@ -1,0 +1,24 @@
+package com.aicodinator.backend.domain.community.domain.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class CommentResponse {
+    private Long commentId;
+
+    private String content;
+
+    private String authorName;
+
+    private Boolean isOwner;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/aicodinator/backend/domain/community/domain/dto/response/MainPageResponse.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/domain/dto/response/MainPageResponse.java
@@ -1,0 +1,22 @@
+package com.aicodinator.backend.domain.community.domain.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class MainPageResponse {
+    private List<PostListResponse> latestPosts;         // 최신글
+
+    private List<PostListResponse> popularPosts;        // 인기글
+
+    private List<PostListResponse> latestCommentPosts;  // 최신 댓글이 달린 글
+
+    private List<PostListResponse> mostCommentedPosts;  // 댓글 많은 글
+}

--- a/src/main/java/com/aicodinator/backend/domain/community/domain/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/domain/dto/response/PostDetailResponse.java
@@ -23,8 +23,6 @@ public class PostDetailResponse {
 
     private List<PostFileResponse> files;
 
-    private List<CommentResponse> comments;
-
     private Boolean isOwner;
 
     private LocalDateTime createdAt;

--- a/src/main/java/com/aicodinator/backend/domain/community/domain/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/domain/dto/response/PostDetailResponse.java
@@ -1,0 +1,33 @@
+package com.aicodinator.backend.domain.community.domain.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class PostDetailResponse {
+    private Long postId;
+
+    private String title;
+
+    private String content;
+
+    private String authorName;
+
+    private List<PostFileResponse> files;
+
+    private List<CommentResponse> comments;
+
+    private Boolean isOwner;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/aicodinator/backend/domain/community/domain/dto/response/PostFileResponse.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/domain/dto/response/PostFileResponse.java
@@ -1,0 +1,18 @@
+package com.aicodinator.backend.domain.community.domain.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class PostFileResponse {
+    private Long fileId;
+
+    private String originalFileName;
+
+    private String fileUrl;
+}

--- a/src/main/java/com/aicodinator/backend/domain/community/domain/dto/response/PostListResponse.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/domain/dto/response/PostListResponse.java
@@ -1,0 +1,22 @@
+package com.aicodinator.backend.domain.community.domain.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class PostListResponse {
+    private Long postId;
+
+    private String title;
+
+    private long viewCount;
+
+    private long likeCount;
+
+    private int commentCount;
+}

--- a/src/main/java/com/aicodinator/backend/domain/community/domain/entity/Board.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/domain/entity/Board.java
@@ -1,7 +1,7 @@
 package com.aicodinator.backend.domain.community.domain.entity;
 
 import com.aicodinator.backend.domain.community.domain.constant.BoardType;
-import com.aicodinator.backend.domain.region.domain.Region;
+import com.aicodinator.backend.domain.region.domain.entity.Region;
 import com.aicodinator.backend.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/aicodinator/backend/domain/community/domain/entity/Post.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/domain/entity/Post.java
@@ -1,5 +1,7 @@
 package com.aicodinator.backend.domain.community.domain.entity;
 
+import com.aicodinator.backend.domain.region.domain.Region;
+import com.aicodinator.backend.domain.user.domain.entity.User;
 import com.aicodinator.backend.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -22,18 +24,60 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "board_id")
     private Board board;
 
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "region_id")
+    private Region region;
+
     @Column(nullable = false)
     private String title;
 
     @Column(length = 1000) // 글자수 체크
     private String content;
 
+    private int likeCount = 0;
+
+    private int commentCount = 0;
+
+    private int viewCount = 0;
+
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<PostFile> files = new ArrayList<>();
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Comment> comments = new ArrayList<>();
+
     public void addFile(PostFile postFile) {
         files.add(postFile);
         postFile.setPost(this);
+    }
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        this.likeCount--;
+    }
+
+    public void increaseCommentCount() {
+        this.commentCount++;
+    }
+
+    public void decreaseCommentCount() {
+        this.commentCount--;
+    }
+
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
+
+    public void decreaseViewCount() {
+        this.viewCount--;
     }
 }

--- a/src/main/java/com/aicodinator/backend/domain/community/domain/entity/Post.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/domain/entity/Post.java
@@ -1,6 +1,6 @@
 package com.aicodinator.backend.domain.community.domain.entity;
 
-import com.aicodinator.backend.domain.region.domain.Region;
+import com.aicodinator.backend.domain.region.domain.entity.Region;
 import com.aicodinator.backend.domain.user.domain.entity.User;
 import com.aicodinator.backend.global.entity.BaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/aicodinator/backend/domain/community/domain/entity/PostFile.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/domain/entity/PostFile.java
@@ -23,7 +23,7 @@ public class PostFile extends BaseEntity {
     private String originalFileName; // 사용자가 업로드한 파일의 원래 이름
 
     @Column(nullable = false)
-    private String uploadUrl; // S3에 업로드된 후 접근할 수 있는 URL
+    private String storedKey; // S3에 업로드된 키
 
     private long fileSize; // 파일 크기
 }

--- a/src/main/java/com/aicodinator/backend/domain/community/mapper/BoardMapper.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/mapper/BoardMapper.java
@@ -1,0 +1,18 @@
+package com.aicodinator.backend.domain.community.mapper;
+
+import com.aicodinator.backend.domain.community.domain.dto.response.BoardResponse;
+import com.aicodinator.backend.domain.community.domain.entity.Board;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface BoardMapper {
+    @Mapping(source = "id", target = "boardId")
+    @Mapping(source = "region.id", target = "regionId")
+    @Mapping(source = "region.name", target = "regionName")
+    BoardResponse toBoardResponse(Board board);
+
+    List<BoardResponse> toBoardResponseList(List<Board> boards);
+}

--- a/src/main/java/com/aicodinator/backend/domain/community/mapper/CommentMapper.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/mapper/CommentMapper.java
@@ -1,0 +1,20 @@
+package com.aicodinator.backend.domain.community.mapper;
+
+import com.aicodinator.backend.domain.community.domain.dto.response.CommentResponse;
+import com.aicodinator.backend.domain.community.domain.entity.Comment;
+import com.aicodinator.backend.domain.user.domain.entity.User;
+import org.mapstruct.Context;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface CommentMapper {
+    @Mapping(source = "id", target = "commentId")
+    @Mapping(source = "user.name", target = "authorName")
+    @Mapping(target = "isOwner", expression = "java(comment.getUser().equals(currentUser))")
+    CommentResponse toCommentResponse(Comment comment, @Context User currentUser);
+
+    List<CommentResponse> toCommentResponseList(List<Comment> commentList);
+}

--- a/src/main/java/com/aicodinator/backend/domain/community/mapper/CommentMapper.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/mapper/CommentMapper.java
@@ -13,8 +13,8 @@ import java.util.List;
 public interface CommentMapper {
     @Mapping(source = "id", target = "commentId")
     @Mapping(source = "user.name", target = "authorName")
-    @Mapping(target = "isOwner", expression = "java(comment.getUser().equals(currentUser))")
+    @Mapping(target = "isOwner", expression = "java(comment.getUser().getId().equals(currentUser.getId()))")
     CommentResponse toCommentResponse(Comment comment, @Context User currentUser);
 
-    List<CommentResponse> toCommentResponseList(List<Comment> commentList);
+    List<CommentResponse> toCommentResponseList(List<Comment> commentList, @Context User currentUser);
 }

--- a/src/main/java/com/aicodinator/backend/domain/community/mapper/PostFileMapper.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/mapper/PostFileMapper.java
@@ -2,22 +2,34 @@ package com.aicodinator.backend.domain.community.mapper;
 
 import com.aicodinator.backend.domain.community.domain.dto.response.PostFileResponse;
 import com.aicodinator.backend.domain.community.domain.entity.PostFile;
+import lombok.extern.slf4j.Slf4j;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
+import java.util.List;
+
+@Slf4j
 @Mapper(componentModel = "spring")
 public abstract class PostFileMapper {
-    @Value("${cloud.aws.s3.base-url}")
-    private String s3BaseUrl;
+    protected String s3BaseUrl;
+
+    @Autowired
+    public void setS3BaseUrl(@Value("${cloud.aws.s3.base-url}") String s3BaseUrl) {
+        log.info("S3 Base URL Injected: {}", s3BaseUrl);
+        this.s3BaseUrl = s3BaseUrl;
+    }
 
     @Mapping(source = "id", target = "fileId")
     public abstract PostFileResponse toPostFileResponse(PostFile postFile);
 
     @AfterMapping
-    protected void afterMapping(PostFile postFile, @MappingTarget PostFileResponse response) {
-        response.setFileUrl(s3BaseUrl + postFile.getStoredKey());
+    protected void afterMapping(PostFile postFile, @MappingTarget PostFileResponse.PostFileResponseBuilder responseBuilder) {
+        log.info("s3BaseUrl in afterMapping: {}", s3BaseUrl);
+        log.info("StoredKey in afterMapping: {}", postFile.getStoredKey());
+        responseBuilder.fileUrl(s3BaseUrl + postFile.getStoredKey());
     }
 }

--- a/src/main/java/com/aicodinator/backend/domain/community/mapper/PostFileMapper.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/mapper/PostFileMapper.java
@@ -1,0 +1,23 @@
+package com.aicodinator.backend.domain.community.mapper;
+
+import com.aicodinator.backend.domain.community.domain.dto.response.PostFileResponse;
+import com.aicodinator.backend.domain.community.domain.entity.PostFile;
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.springframework.beans.factory.annotation.Value;
+
+@Mapper(componentModel = "spring")
+public abstract class PostFileMapper {
+    @Value("${cloud.aws.s3.base-url}")
+    private String s3BaseUrl;
+
+    @Mapping(source = "id", target = "fileId")
+    public abstract PostFileResponse toPostFileResponse(PostFile postFile);
+
+    @AfterMapping
+    protected void afterMapping(PostFile postFile, @MappingTarget PostFileResponse response) {
+        response.setFileUrl(s3BaseUrl + postFile.getStoredKey());
+    }
+}

--- a/src/main/java/com/aicodinator/backend/domain/community/mapper/PostMapper.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/mapper/PostMapper.java
@@ -13,12 +13,12 @@ import java.util.List;
 
 @Mapper(
     componentModel = "spring",
-    uses = {PostFileMapper.class, CommentMapper.class}
+    uses = {PostFileMapper.class}
 )
 public interface PostMapper {
     @Mapping(source = "id", target = "postId")
     @Mapping(source = "user.name", target = "authorName")
-    @Mapping(target = "isOwner", expression = "java(post.getUser().equals(currentUser))")
+    @Mapping(target = "isOwner", expression = "java(post.getUser().getId().equals(currentUser.getId()))")
     PostDetailResponse toPostDetailResponse(Post post, @Context User currentUser);
 
     @Mapping(source = "id", target = "postId")

--- a/src/main/java/com/aicodinator/backend/domain/community/mapper/PostMapper.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/mapper/PostMapper.java
@@ -1,0 +1,28 @@
+package com.aicodinator.backend.domain.community.mapper;
+
+import com.aicodinator.backend.domain.community.domain.dto.response.PostDetailResponse;
+import com.aicodinator.backend.domain.community.domain.dto.response.PostListResponse;
+import com.aicodinator.backend.domain.community.domain.entity.Post;
+import com.aicodinator.backend.domain.user.domain.entity.User;
+import org.mapstruct.Context;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Mapper(
+    componentModel = "spring",
+    uses = {PostFileMapper.class, CommentMapper.class}
+)
+public interface PostMapper {
+    @Mapping(source = "id", target = "postId")
+    @Mapping(source = "user.name", target = "authorName")
+    @Mapping(target = "isOwner", expression = "java(post.getUser().equals(currentUser))")
+    PostDetailResponse toPostDetailResponse(Post post, @Context User currentUser);
+
+    @Mapping(source = "id", target = "postId")
+    PostListResponse toPostListResponse(Post post);
+
+    List<PostListResponse> toPostListResponseList(List<Post> posts);
+}

--- a/src/main/java/com/aicodinator/backend/domain/community/repository/BoardRepository.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/repository/BoardRepository.java
@@ -1,7 +1,7 @@
 package com.aicodinator.backend.domain.community.repository;
 
 import com.aicodinator.backend.domain.community.domain.entity.Board;
-import com.aicodinator.backend.domain.region.domain.Region;
+import com.aicodinator.backend.domain.region.domain.entity.Region;
 import com.aicodinator.backend.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/aicodinator/backend/domain/community/repository/BoardRepository.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/repository/BoardRepository.java
@@ -1,9 +1,29 @@
 package com.aicodinator.backend.domain.community.repository;
 
 import com.aicodinator.backend.domain.community.domain.entity.Board;
+import com.aicodinator.backend.domain.region.domain.Region;
+import com.aicodinator.backend.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface BoardRepository extends JpaRepository<Board,Long> {
+    List<Board> findByRegion(Region region);
+
+    List<Board> findByRegionId(Long regionId);
+
+    /**
+     * 특정 사용자가 속한 지역들의 모든 게시판 조회
+     * @param user
+     * @return 게시판 리스트
+     */
+    @Query("SELECT b FROM Board b WHERE b.region IN " +
+        "(SELECT ur.region FROM UserRegion ur WHERE ur.user = :user)")
+    List<Board> findBoardsForUserRegions(@Param("user") User user);
+
+    Long region(Region region);
 }

--- a/src/main/java/com/aicodinator/backend/domain/community/repository/CommentRepository.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/repository/CommentRepository.java
@@ -4,6 +4,9 @@ import com.aicodinator.backend.domain.community.domain.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findAllByPostIdOrderByCreatedAtAsc(Long postId);
 }

--- a/src/main/java/com/aicodinator/backend/domain/community/repository/PostLikeRepository.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/repository/PostLikeRepository.java
@@ -1,9 +1,13 @@
 package com.aicodinator.backend.domain.community.repository;
 
 import com.aicodinator.backend.domain.community.domain.entity.PostLike;
+import com.aicodinator.backend.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    boolean existsByPostIdAndUser(Long postId, User user);
+
+    void deleteByPostIdAndUser(Long postId, User user);
 }

--- a/src/main/java/com/aicodinator/backend/domain/community/repository/PostRepository.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/repository/PostRepository.java
@@ -2,7 +2,7 @@ package com.aicodinator.backend.domain.community.repository;
 
 import com.aicodinator.backend.domain.community.domain.entity.Board;
 import com.aicodinator.backend.domain.community.domain.entity.Post;
-import com.aicodinator.backend.domain.region.domain.Region;
+import com.aicodinator.backend.domain.region.domain.entity.Region;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -26,8 +26,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p " +
         "LEFT JOIN FETCH p.user " +
         "LEFT JOIN FETCH p.files " +
-        "LEFT JOIN FETCH p.comments c " +
-        "LEFT JOIN FETCH c.user " +
         "WHERE p.id = :postId")
     Optional<Post> findByIdWithDetails(@Param("postId") Long postId);
 

--- a/src/main/java/com/aicodinator/backend/domain/community/repository/PostRepository.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/repository/PostRepository.java
@@ -1,9 +1,56 @@
 package com.aicodinator.backend.domain.community.repository;
 
+import com.aicodinator.backend.domain.community.domain.entity.Board;
 import com.aicodinator.backend.domain.community.domain.entity.Post;
+import com.aicodinator.backend.domain.region.domain.Region;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+    /**
+     * 게시판별 게시글 페이지네이션 조회
+     */
+    Page<Post> findByBoard(Board board, Pageable pageable);
+
+    /**
+     * 게시글 상세 조회 Fetch Join
+     */
+    @Query("SELECT p FROM Post p " +
+        "LEFT JOIN FETCH p.user " +
+        "LEFT JOIN FETCH p.files " +
+        "LEFT JOIN FETCH p.comments c " +
+        "LEFT JOIN FETCH c.user " +
+        "WHERE p.id = :postId")
+    Optional<Post> findByIdWithDetails(@Param("postId") Long postId);
+
+    /**
+     * 최신글 3개 조회
+     */
+    List<Post> findTop3ByRegionOrderByCreatedAtDesc(Region region, Pageable pageable);
+
+    /**
+     * 인기글 3개 조회
+     */
+    @Query("SELECT p FROM Post p WHERE p.region = :region ORDER BY p.likeCount DESC")
+    List<Post> findTop3PopularPosts(@Param("region") Region region, Pageable pageable);
+
+    /**
+     * 댓글 많은 글 3개 조회
+     */
+    @Query("SELECT p FROM Post p WHERE p.region = :region ORDER BY SIZE(p.comments) DESC")
+    List<Post> findTop3MostCommentedPosts(@Param("region") Region region, Pageable pageable);
+
+    /**
+     * 최신 댓글이 달린 글 3개 조회
+     */
+    @Query("SELECT c.post FROM Comment c WHERE c.post.region = :region GROUP BY c.post ORDER BY MAX(c.createdAt) DESC")
+    List<Post> findTop3LatestCommentedPosts(@Param("region") Region region, Pageable pageable);
 }

--- a/src/main/java/com/aicodinator/backend/domain/community/service/BoardService.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/service/BoardService.java
@@ -1,9 +1,12 @@
 package com.aicodinator.backend.domain.community.service;
 
 import com.aicodinator.backend.domain.community.domain.constant.BoardType;
+import com.aicodinator.backend.domain.community.domain.dto.response.BoardResponse;
 import com.aicodinator.backend.domain.community.domain.entity.Board;
+import com.aicodinator.backend.domain.community.mapper.BoardMapper;
 import com.aicodinator.backend.domain.community.repository.BoardRepository;
-import com.aicodinator.backend.domain.region.domain.Region;
+import com.aicodinator.backend.domain.region.domain.entity.Region;
+import com.aicodinator.backend.domain.region.service.RegionService;
 import com.aicodinator.backend.domain.user.domain.entity.User;
 import com.aicodinator.backend.global.exception.CustomException;
 import com.aicodinator.backend.global.exception.ErrorCode;
@@ -16,6 +19,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class BoardService {
     private final BoardRepository boardRepository;
+    private final RegionService regionService;
+    private final BoardMapper boardMapper;
 
     public Board findById(long id) {
         return boardRepository.findById(id)
@@ -26,15 +31,16 @@ public class BoardService {
         return boardRepository.findByRegion(region);
     }
 
-    public List<Board> findByRegionId(Long regionId) {
-        return boardRepository.findByRegionId(regionId);
+    public List<BoardResponse> findByRegionId(Long regionId) {
+        return boardMapper.toBoardResponseList(boardRepository.findByRegionId(regionId));
     }
 
     public List<Board> findByUser(User user) {
         return boardRepository.findBoardsForUserRegions(user);
     }
 
-    public void createBoards(Region region) {
+    public void createBoards(Long regionId) {
+        Region region = regionService.findById(regionId);
         if (findByRegion(region).size() >= 4) return;
 
         List<BoardType> boardTypes = List.of(BoardType.FREE, BoardType.QNA, BoardType.REVIEW, BoardType.PROMO);

--- a/src/main/java/com/aicodinator/backend/domain/community/service/BoardService.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/service/BoardService.java
@@ -1,11 +1,51 @@
 package com.aicodinator.backend.domain.community.service;
 
+import com.aicodinator.backend.domain.community.domain.constant.BoardType;
+import com.aicodinator.backend.domain.community.domain.entity.Board;
 import com.aicodinator.backend.domain.community.repository.BoardRepository;
+import com.aicodinator.backend.domain.region.domain.Region;
+import com.aicodinator.backend.domain.user.domain.entity.User;
+import com.aicodinator.backend.global.exception.CustomException;
+import com.aicodinator.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class BoardService {
     private final BoardRepository boardRepository;
+
+    public Board findById(long id) {
+        return boardRepository.findById(id)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "요청하신 게시판을 찾을 수 없습니다."));
+    }
+
+    public List<Board> findByRegion(Region region) {
+        return boardRepository.findByRegion(region);
+    }
+
+    public List<Board> findByRegionId(Long regionId) {
+        return boardRepository.findByRegionId(regionId);
+    }
+
+    public List<Board> findByUser(User user) {
+        return boardRepository.findBoardsForUserRegions(user);
+    }
+
+    public void createBoards(Region region) {
+        if (findByRegion(region).size() >= 4) return;
+
+        List<BoardType> boardTypes = List.of(BoardType.FREE, BoardType.QNA, BoardType.REVIEW, BoardType.PROMO);
+
+        List<Board> boards = boardTypes.stream()
+            .map(boardType ->
+                Board.builder()
+                    .region(region)
+                    .boardType(boardType)
+                    .build())
+            .toList();
+        boardRepository.saveAll(boards);
+    }
 }

--- a/src/main/java/com/aicodinator/backend/domain/community/service/CommentService.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/service/CommentService.java
@@ -24,8 +24,8 @@ public class CommentService {
     private final CommentMapper commentMapper;
 
     @Transactional(readOnly = true)
-    public List<CommentResponse> getCommentsByPostId(Long postId) {
-        return commentMapper.toCommentResponseList(commentRepository.findAllByPostIdOrderByCreatedAtAsc(postId));
+    public List<CommentResponse> getCommentsByPostId(Long postId, User user) {
+        return commentMapper.toCommentResponseList(commentRepository.findAllByPostIdOrderByCreatedAtAsc(postId), user);
     }
 
     @Transactional
@@ -57,7 +57,7 @@ public class CommentService {
         Comment comment = commentRepository.findById(commentId)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "요청하신 댓글을 찾을 수 없습니다."));
 
-        if (!user.equals(comment.getUser())) {
+        if (!user.getId().equals(comment.getUser().getId())) {
             throw new CustomException(ErrorCode.FORBIDDEN, "해당 댓글에 대한 권한이 없습니다.");
         }
 

--- a/src/main/java/com/aicodinator/backend/domain/community/service/CommentService.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/service/CommentService.java
@@ -1,11 +1,66 @@
 package com.aicodinator.backend.domain.community.service;
 
+import com.aicodinator.backend.domain.community.domain.dto.request.CommentEditRequest;
+import com.aicodinator.backend.domain.community.domain.dto.request.CommentRequest;
+import com.aicodinator.backend.domain.community.domain.dto.response.CommentResponse;
+import com.aicodinator.backend.domain.community.domain.entity.Comment;
+import com.aicodinator.backend.domain.community.domain.entity.Post;
+import com.aicodinator.backend.domain.community.mapper.CommentMapper;
 import com.aicodinator.backend.domain.community.repository.CommentRepository;
+import com.aicodinator.backend.domain.user.domain.entity.User;
+import com.aicodinator.backend.global.exception.CustomException;
+import com.aicodinator.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
     private final CommentRepository commentRepository;
+    private final PostService postService;
+    private final CommentMapper commentMapper;
+
+    @Transactional(readOnly = true)
+    public List<CommentResponse> getCommentsByPostId(Long postId) {
+        return commentMapper.toCommentResponseList(commentRepository.findAllByPostIdOrderByCreatedAtAsc(postId));
+    }
+
+    @Transactional
+    public CommentResponse createComment(CommentRequest request, User user) {
+        Post post = postService.findById(request.getPostId());
+
+        Comment comment = commentRepository.save(Comment.builder()
+            .post(post)
+            .user(user)
+            .content(request.getContent())
+            .build());
+
+        return commentMapper.toCommentResponse(comment, user);
+    }
+
+    @Transactional
+    public CommentResponse updateComment(Long commentId, CommentEditRequest request, User user) {
+        Comment comment = findCommentAndValidate(commentId, user);
+        comment.setContent(request.getContent());
+        return commentMapper.toCommentResponse(commentRepository.save(comment), user);
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId, User user) {
+        commentRepository.delete(findCommentAndValidate(commentId, user));
+    }
+
+    private Comment findCommentAndValidate(Long commentId, User user) {
+        Comment comment = commentRepository.findById(commentId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "요청하신 댓글을 찾을 수 없습니다."));
+
+        if (!user.equals(comment.getUser())) {
+            throw new CustomException(ErrorCode.FORBIDDEN, "해당 댓글에 대한 권한이 없습니다.");
+        }
+
+        return comment;
+    }
 }

--- a/src/main/java/com/aicodinator/backend/domain/community/service/FileValidator.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/service/FileValidator.java
@@ -1,0 +1,80 @@
+package com.aicodinator.backend.domain.community.service;
+
+import com.aicodinator.backend.global.exception.CustomException;
+import com.aicodinator.backend.global.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Slf4j
+@Component
+public class FileValidator {
+    private static final int MAX_FILE_COUNT = 5;
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+    /**
+     * 파일 생성 시 유효성 검증 - 최대 파일 개수 초과 여부, 각 파일별 검증
+     * @param files 새로 추가될 파일 리스트
+     */
+    public void validate(List<MultipartFile> files) {
+        if (files == null || files.isEmpty()) {
+            return;
+        }
+
+        List<MultipartFile> actualFiles = files.stream()
+            .filter(file -> file != null && !file.isEmpty())
+            .toList();
+
+        if (actualFiles.size() > MAX_FILE_COUNT) {
+            log.warn("파일 업로드 개수 제한을 초과했습니다. 허용: {}개, 요청: {}개", MAX_FILE_COUNT, actualFiles.size());
+            throw new CustomException(ErrorCode.INVALID_FILE_REQUEST, "파일은 최대 " + MAX_FILE_COUNT + "개까지 업로드할 수 있습니다.");
+        }
+
+        for (MultipartFile file : actualFiles) {
+            validateSingleFile(file);
+        }
+    }
+
+    /**
+     * 파일 수정 시 유효성 검증 - 최대 파일 개수 초과 여부, 각 파일별 검증
+     * @param files 새로 추가될 파일 리스트
+     * @param currentFileCount 수정 전 파일 개수
+     * @param deleteFileCount 삭제할 파일 개수
+     */
+    public void validate(List<MultipartFile> files, int currentFileCount, int deleteFileCount) {
+        if (files == null || files.isEmpty()) {
+            return;
+        }
+
+        List<MultipartFile> actualFiles = files.stream()
+            .filter(file -> file != null && !file.isEmpty())
+            .toList();
+
+        int totalCount = currentFileCount - deleteFileCount + actualFiles.size();
+        if (totalCount > MAX_FILE_COUNT) {
+            log.warn("파일 업로드 개수 제한을 초과했습니다. 허용: {}개, 요청: {}개", MAX_FILE_COUNT, totalCount);
+            throw new CustomException(ErrorCode.INVALID_FILE_REQUEST, "파일은 최대 " + MAX_FILE_COUNT + "개까지 업로드할 수 있습니다.");
+        }
+
+        for (MultipartFile file : actualFiles) {
+            validateSingleFile(file);
+        }
+    }
+
+    /**
+     * 단일 파일 검증 - 파일명 존재 여부, 파일 최대 크기 초과 여부 검증
+     * @param file 검증할 MultipartFile
+     */
+    private void validateSingleFile(MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || originalFilename.isEmpty()) {
+            log.error("업로드할 파일의 원본 파일명이 비어있거나 존재하지 않습니다.");
+            throw new CustomException(ErrorCode.INVALID_FILE_REQUEST);
+        }
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new CustomException(ErrorCode.INVALID_FILE_REQUEST, "파일 크기는 " + (MAX_FILE_SIZE / 1024 / 1024) + "MB를 초과할 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/aicodinator/backend/domain/community/service/PostService.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/service/PostService.java
@@ -11,9 +11,10 @@ import com.aicodinator.backend.domain.community.domain.entity.Post;
 import com.aicodinator.backend.domain.community.domain.entity.PostFile;
 import com.aicodinator.backend.domain.community.domain.entity.PostLike;
 import com.aicodinator.backend.domain.community.mapper.PostMapper;
+import com.aicodinator.backend.domain.community.repository.PostFileRepository;
 import com.aicodinator.backend.domain.community.repository.PostLikeRepository;
 import com.aicodinator.backend.domain.community.repository.PostRepository;
-import com.aicodinator.backend.domain.region.domain.Region;
+import com.aicodinator.backend.domain.region.domain.entity.Region;
 import com.aicodinator.backend.domain.region.service.RegionService;
 import com.aicodinator.backend.domain.user.domain.entity.User;
 import com.aicodinator.backend.global.exception.CustomException;
@@ -38,6 +39,7 @@ public class PostService {
     private final FileValidator fileValidator;
     private final RegionService regionService;
     private final PostLikeRepository postLikeRepository;
+    private final PostFileRepository postFileRepository;
 
     @Transactional(readOnly = true)
     public Post findById(long id) {
@@ -155,7 +157,7 @@ public class PostService {
     private Post findPostAndValidate(Long postId, User user) {
         Post post = findById(postId);
 
-        if (!user.equals(post.getUser())) {
+        if (!user.getId().equals(post.getUser().getId())) {
             throw new CustomException(ErrorCode.FORBIDDEN, "요청하신 게시글에 대한 권한이 없습니다.");
         }
 
@@ -176,14 +178,15 @@ public class PostService {
                 post.addFile(postFile);
             }
         }
+        postFileRepository.saveAll(post.getFiles());
     }
 
     private void deleteFiles(List<PostFile> files, Post post) {
         if (!files.isEmpty()) {
             for (PostFile file : files) {
                 s3Uploader.delete(file.getStoredKey());
-                post.getFiles().remove(file);
             }
         }
+        post.getFiles().removeAll(files);
     }
 }

--- a/src/main/java/com/aicodinator/backend/domain/community/service/PostService.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/service/PostService.java
@@ -1,11 +1,189 @@
 package com.aicodinator.backend.domain.community.service;
 
+import com.aicodinator.backend.domain.community.domain.constant.UploadType;
+import com.aicodinator.backend.domain.community.domain.dto.request.PostEditRequest;
+import com.aicodinator.backend.domain.community.domain.dto.request.PostRequest;
+import com.aicodinator.backend.domain.community.domain.dto.response.MainPageResponse;
+import com.aicodinator.backend.domain.community.domain.dto.response.PostDetailResponse;
+import com.aicodinator.backend.domain.community.domain.dto.response.PostListResponse;
+import com.aicodinator.backend.domain.community.domain.entity.Board;
+import com.aicodinator.backend.domain.community.domain.entity.Post;
+import com.aicodinator.backend.domain.community.domain.entity.PostFile;
+import com.aicodinator.backend.domain.community.domain.entity.PostLike;
+import com.aicodinator.backend.domain.community.mapper.PostMapper;
+import com.aicodinator.backend.domain.community.repository.PostLikeRepository;
 import com.aicodinator.backend.domain.community.repository.PostRepository;
+import com.aicodinator.backend.domain.region.domain.Region;
+import com.aicodinator.backend.domain.region.service.RegionService;
+import com.aicodinator.backend.domain.user.domain.entity.User;
+import com.aicodinator.backend.global.exception.CustomException;
+import com.aicodinator.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
+    private final BoardService boardService;
+    private final S3Uploader s3Uploader;
+    private final PostMapper postMapper;
+    private final FileValidator fileValidator;
+    private final RegionService regionService;
+    private final PostLikeRepository postLikeRepository;
+
+    @Transactional(readOnly = true)
+    public Post findById(long id) {
+        return postRepository.findById(id)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "요청하신 게시글을 찾을 수 없습니다."));
+    }
+
+    @Transactional(readOnly = true)
+    public PostDetailResponse getPostDetail(Long postId, User user) {
+        Post post = postRepository.findByIdWithDetails(postId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "요청하신 게시글을 찾을 수 없습니다."));
+        post.increaseViewCount();
+
+        return postMapper.toPostDetailResponse(post, user);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PostListResponse> getPostList(Long boardId, Pageable pageable) {
+        Board board = boardService.findById(boardId);
+        return postRepository.findByBoard(board, pageable)
+            .map(postMapper::toPostListResponse);
+    }
+
+    @Transactional(readOnly = true)
+    public MainPageResponse getMainPagePosts(Long regionId) {
+        Region region = regionService.findById(regionId);
+
+        Pageable limit3 = PageRequest.of(0, 3);
+        List<Post> latestPosts = postRepository.findTop3ByRegionOrderByCreatedAtDesc(region, limit3);
+        List<Post> popularPosts = postRepository.findTop3PopularPosts(region, limit3);
+        List<Post> latestCommentedPosts = postRepository.findTop3LatestCommentedPosts(region, limit3);
+        List<Post> mostCommentedPosts = postRepository.findTop3MostCommentedPosts(region, limit3);
+
+        return MainPageResponse.builder()
+            .latestPosts(postMapper.toPostListResponseList(latestPosts))
+            .popularPosts(postMapper.toPostListResponseList(popularPosts))
+            .latestCommentPosts(postMapper.toPostListResponseList(latestCommentedPosts))
+            .mostCommentedPosts(postMapper.toPostListResponseList(mostCommentedPosts))
+            .build();
+    }
+
+    @Transactional
+    public PostDetailResponse createPost(PostRequest request, List<MultipartFile> files, User user) {
+        fileValidator.validate(files);
+
+        Board board = boardService.findById(request.getBoardId());
+        Post post = Post.builder()
+            .board(board)
+            .title(request.getTitle())
+            .content(request.getContent())
+            .user(user)
+            .region(board.getRegion())
+            .build();
+
+        postRepository.save(post);
+        uploadFiles(files, post);
+
+        return postMapper.toPostDetailResponse(post, user);
+    }
+
+    @Transactional
+    public PostDetailResponse updatePost(Long postId, PostEditRequest request, List<MultipartFile> newFiles, User user) {
+        Post post = findPostAndValidate(postId, user);
+
+        int currentFileCount = post.getFiles().size();
+        int deleteFileCount = request.getDeleteFileIds() != null ? request.getDeleteFileIds().size() : 0;
+        fileValidator.validate(newFiles, currentFileCount, deleteFileCount);
+
+        post.setTitle(request.getTitle());
+        post.setContent(request.getContent());
+
+        if (request.getDeleteFileIds() != null && !request.getDeleteFileIds().isEmpty()) {
+            List<PostFile> filesToDelete = post.getFiles()
+                .stream().filter(file -> request.getDeleteFileIds().contains(file.getId()))
+                .toList();
+
+            deleteFiles(filesToDelete, post);
+        }
+
+        uploadFiles(newFiles, post);
+        return postMapper.toPostDetailResponse(post, user);
+    }
+
+    @Transactional
+    public void deletePost(Long postId, User user) {
+        Post post = findPostAndValidate(postId, user);
+
+        deleteFiles(post.getFiles(), post);
+
+        postRepository.delete(post);
+    }
+
+    @Transactional(readOnly = true)
+    public Boolean isLikedPost(Long postId, User user) {
+        return postLikeRepository.existsByPostIdAndUser(postId, user);
+    }
+
+    @Transactional
+    public Boolean likePost(Long postId, User user) {
+        Post post = findById(postId);
+        if (postLikeRepository.existsByPostIdAndUser(postId, user)) {
+            return true;
+        }
+
+        postLikeRepository.save(PostLike.builder().post(post).user(user).build());
+        return true;
+    }
+
+    @Transactional
+    public Boolean unlikePost(Long postId, User user) {
+        postLikeRepository.deleteByPostIdAndUser(postId, user);
+        return false;
+    }
+
+    private Post findPostAndValidate(Long postId, User user) {
+        Post post = findById(postId);
+
+        if (!user.equals(post.getUser())) {
+            throw new CustomException(ErrorCode.FORBIDDEN, "요청하신 게시글에 대한 권한이 없습니다.");
+        }
+
+        return post;
+    }
+
+    private void uploadFiles(List<MultipartFile> files, Post post) {
+        if (files != null && !files.isEmpty()) {
+            for (MultipartFile file : files) {
+                String storedKey = s3Uploader.upload(file, UploadType.COMMUNITY_POST);
+
+                PostFile postFile = PostFile.builder()
+                    .originalFileName(file.getOriginalFilename())
+                    .storedKey(storedKey)
+                    .fileSize(file.getSize())
+                    .build();
+
+                post.addFile(postFile);
+            }
+        }
+    }
+
+    private void deleteFiles(List<PostFile> files, Post post) {
+        if (!files.isEmpty()) {
+            for (PostFile file : files) {
+                s3Uploader.delete(file.getStoredKey());
+                post.getFiles().remove(file);
+            }
+        }
+    }
 }

--- a/src/main/java/com/aicodinator/backend/domain/community/service/S3Uploader.java
+++ b/src/main/java/com/aicodinator/backend/domain/community/service/S3Uploader.java
@@ -1,0 +1,111 @@
+package com.aicodinator.backend.domain.community.service;
+
+import com.aicodinator.backend.domain.community.domain.constant.FileExtension;
+import com.aicodinator.backend.domain.community.domain.constant.UploadType;
+import com.aicodinator.backend.global.exception.CustomException;
+import com.aicodinator.backend.global.exception.ErrorCode;
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3Uploader {
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    /**
+     * S3 파일 업로드
+     * @param file 업로드할 MultipartFile
+     * @param uploadType 파일 용도 (COMMUNITY_POST / REPORT)
+     * @return 업로드된 파일의 S3 키
+     */
+    public String upload(MultipartFile file, UploadType uploadType) {
+        // 원본 파일명 추출
+        String originalFileName =  file.getOriginalFilename();
+
+        // 파일 확장자 Enum 추출
+        FileExtension extension = FileExtension.fromFileName(originalFileName);
+
+        // 저장 경로 생성
+        String storedKey = generateStoredKey(uploadType, extension);
+        log.debug("S3에 저장될 파일명이 생성되었습니다: {}", storedKey);
+
+        // 메타 데이터 생성
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(file.getSize());
+        objectMetadata.setContentType(extension.getContentType());
+
+        // S3에 파일 업로드
+        try {
+            amazonS3.putObject(new PutObjectRequest(bucket, storedKey, file.getInputStream(), objectMetadata));
+            log.debug("S3 파일 업로드에 성공했습니다: {}", storedKey);
+        } catch (AmazonServiceException ase) {
+            log.error("S3 파일 업로드 중 AmazonServiceException가 발생했습니다: {} {} {} ", bucket, storedKey, ase.getMessage());
+            throw new CustomException(ErrorCode.S3_UPLOAD_AMAZON_ERROR, "S3 서비스 에러로 인해 파일 업로드에 실패했습니다.");
+        } catch (AmazonClientException ace) {
+            log.error("S3 파일 업로드 중 AmazonClientException가 발생했습니다: {} {} {} ", bucket, storedKey, ace.getMessage());
+            throw new CustomException(ErrorCode.S3_UPLOAD_AMAZON_ERROR, "S3 클라이언트 에러로 인해 파일 업로드에 실패했습니다.");
+        } catch (IOException e) {
+            log.error("S3 파일 업로드 중 파일 스트림 오류가 발생했습니다: {} {} {}", bucket, storedKey, e.getMessage());
+            throw new CustomException(ErrorCode.S3_UPLOAD_FAILED);
+        }
+
+        // 업로드한 파일의 S3 키 반환
+        return storedKey;
+    }
+
+    /**
+     * S3 파일 삭제
+     * @param storedKey 삭제할 파일의 S3 키
+     */
+    public void delete(String storedKey) {
+        // S3 키 검증
+        if (storedKey == null || storedKey.isEmpty()) {
+            log.warn("삭제할 S3 키가 비어있거나 존재하지 않습니다.");
+            return;
+        }
+
+        // S3에서 파일 삭제
+        try {
+            amazonS3.deleteObject(new DeleteObjectRequest(bucket, storedKey));
+            log.debug("S3 파일 삭제에 성공했습니다: {}", storedKey);
+        } catch (AmazonServiceException ase) {
+            log.error("S3 파일 삭제 중 AmazonServiceException가 발생했습니다: {} {} {} ", bucket, storedKey, ase.getMessage());
+            throw new CustomException(ErrorCode.S3_DELETE_AMAZON_ERROR, "S3 서비스 에러로 인해 파일 삭제에 실패했습니다.");
+        } catch (AmazonClientException ace) {
+            log.error("S3 파일 삭제 중 AmazonClientException가 발생했습니다: {} {} {} ", bucket, storedKey, ace.getMessage());
+            throw new CustomException(ErrorCode.S3_DELETE_AMAZON_ERROR, "S3 클라이언트 에러로 인해 파일 삭제에 실패했습니다.");
+        } catch (Exception e) {
+            log.error("S3 파일 삭제 중 오류가 발생했습니다: {} {} {}", bucket, storedKey, e.getMessage());
+            throw new CustomException(ErrorCode.S3_DELETE_FAILED);
+        }
+    }
+
+    /**
+     * dirName/yyyyMMdd/UUID.(확장자) 저장 경로 생성
+     * @param uploadType UploadType
+     * @return 생성된 저장 경로
+     */
+    private String generateStoredKey(UploadType uploadType, FileExtension extension) {
+        String date = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+        return String.format("%s/%s/%s.%s", uploadType, date, UUID.randomUUID(), extension.getExtension());
+    }
+}

--- a/src/main/java/com/aicodinator/backend/domain/region/controller/RegionController.java
+++ b/src/main/java/com/aicodinator/backend/domain/region/controller/RegionController.java
@@ -1,12 +1,13 @@
 package com.aicodinator.backend.domain.region.controller;
 
-import com.aicodinator.backend.domain.region.domain.Region;
+import com.aicodinator.backend.domain.region.domain.dto.RegionResponse;
 import com.aicodinator.backend.domain.region.service.RegionService;
-import com.aicodinator.backend.domain.user.domain.entity.User;
+import com.aicodinator.backend.global.security.CustomOAuth2User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,13 +15,12 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/regions")
+@RequestMapping("/api/")
 public class RegionController {
     private final RegionService regionService;
 
-    @GetMapping("/my")
-    public ResponseEntity<List<Region>> findMyRegions(@AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(regionService.findMyRegions(user));
+    @GetMapping("/my/regions")
+    public ResponseEntity<List<RegionResponse>> findMyRegions(@AuthenticationPrincipal CustomOAuth2User oAuth2User) {
+        return ResponseEntity.ok(regionService.findMyRegions(oAuth2User.getUser()));
     }
-    // TODO: CustomOAuth2UserPrincipal로 변경
 }

--- a/src/main/java/com/aicodinator/backend/domain/region/controller/RegionController.java
+++ b/src/main/java/com/aicodinator/backend/domain/region/controller/RegionController.java
@@ -1,11 +1,26 @@
 package com.aicodinator.backend.domain.region.controller;
 
+import com.aicodinator.backend.domain.region.domain.Region;
 import com.aicodinator.backend.domain.region.service.RegionService;
+import com.aicodinator.backend.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/regions")
 public class RegionController {
     private final RegionService regionService;
+
+    @GetMapping("/my")
+    public ResponseEntity<List<Region>> findMyRegions(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(regionService.findMyRegions(user));
+    }
+    // TODO: CustomOAuth2UserPrincipal로 변경
 }

--- a/src/main/java/com/aicodinator/backend/domain/region/domain/dto/RegionResponse.java
+++ b/src/main/java/com/aicodinator/backend/domain/region/domain/dto/RegionResponse.java
@@ -1,0 +1,12 @@
+package com.aicodinator.backend.domain.region.domain.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RegionResponse {
+    private Long regionId;
+
+    private String regionName;
+}

--- a/src/main/java/com/aicodinator/backend/domain/region/domain/entity/Region.java
+++ b/src/main/java/com/aicodinator/backend/domain/region/domain/entity/Region.java
@@ -1,4 +1,4 @@
-package com.aicodinator.backend.domain.region.domain;
+package com.aicodinator.backend.domain.region.domain.entity;
 
 import com.aicodinator.backend.global.entity.BaseEntity;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/aicodinator/backend/domain/region/domain/entity/UserRegion.java
+++ b/src/main/java/com/aicodinator/backend/domain/region/domain/entity/UserRegion.java
@@ -1,4 +1,4 @@
-package com.aicodinator.backend.domain.region.domain;
+package com.aicodinator.backend.domain.region.domain.entity;
 
 import com.aicodinator.backend.domain.user.domain.entity.User;
 import jakarta.persistence.*;

--- a/src/main/java/com/aicodinator/backend/domain/region/mapper/RegionMapper.java
+++ b/src/main/java/com/aicodinator/backend/domain/region/mapper/RegionMapper.java
@@ -1,0 +1,17 @@
+package com.aicodinator.backend.domain.region.mapper;
+
+import com.aicodinator.backend.domain.region.domain.dto.RegionResponse;
+import com.aicodinator.backend.domain.region.domain.entity.Region;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface RegionMapper {
+    @Mapping(source = "id", target = "regionId")
+    @Mapping(source = "name", target = "regionName")
+    RegionResponse toRegionResponse(Region region);
+
+    List<RegionResponse> toRegionResponseList(List<Region> regions);
+}

--- a/src/main/java/com/aicodinator/backend/domain/region/repository/RegionRepository.java
+++ b/src/main/java/com/aicodinator/backend/domain/region/repository/RegionRepository.java
@@ -1,6 +1,6 @@
 package com.aicodinator.backend.domain.region.repository;
 
-import com.aicodinator.backend.domain.region.domain.Region;
+import com.aicodinator.backend.domain.region.domain.entity.Region;
 import com.aicodinator.backend.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/aicodinator/backend/domain/region/repository/RegionRepository.java
+++ b/src/main/java/com/aicodinator/backend/domain/region/repository/RegionRepository.java
@@ -1,9 +1,21 @@
 package com.aicodinator.backend.domain.region.repository;
 
 import com.aicodinator.backend.domain.region.domain.Region;
+import com.aicodinator.backend.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface RegionRepository extends JpaRepository<Region,Long> {
+    /**
+     * 특정 사용자의 지역 조회
+     * @param user 조회할 사용자
+     * @return 해당 사용자의 지역 리스트
+     */
+    @Query("SELECT ur.region FROM UserRegion ur WHERE ur.user = :user")
+    List<Region> findRegionsByUser(@Param("user") User user);
 }

--- a/src/main/java/com/aicodinator/backend/domain/region/service/RegionService.java
+++ b/src/main/java/com/aicodinator/backend/domain/region/service/RegionService.java
@@ -1,6 +1,8 @@
 package com.aicodinator.backend.domain.region.service;
 
-import com.aicodinator.backend.domain.region.domain.Region;
+import com.aicodinator.backend.domain.region.domain.dto.RegionResponse;
+import com.aicodinator.backend.domain.region.domain.entity.Region;
+import com.aicodinator.backend.domain.region.mapper.RegionMapper;
 import com.aicodinator.backend.domain.region.repository.RegionRepository;
 import com.aicodinator.backend.domain.user.domain.entity.User;
 import com.aicodinator.backend.global.exception.CustomException;
@@ -14,13 +16,14 @@ import java.util.List;
 @RequiredArgsConstructor
 public class RegionService {
     private final RegionRepository regionRepository;
+    private final RegionMapper regionMapper;
 
     public Region findById(Long regionId) {
         return regionRepository.findById(regionId)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "요청하신 지역을 찾을 수 없습니다."));
     }
 
-    public List<Region> findMyRegions(User user) {
-        return regionRepository.findRegionsByUser(user);
+    public List<RegionResponse> findMyRegions(User user) {
+        return regionMapper.toRegionResponseList(regionRepository.findRegionsByUser(user));
     }
 }

--- a/src/main/java/com/aicodinator/backend/domain/region/service/RegionService.java
+++ b/src/main/java/com/aicodinator/backend/domain/region/service/RegionService.java
@@ -1,11 +1,26 @@
 package com.aicodinator.backend.domain.region.service;
 
+import com.aicodinator.backend.domain.region.domain.Region;
 import com.aicodinator.backend.domain.region.repository.RegionRepository;
+import com.aicodinator.backend.domain.user.domain.entity.User;
+import com.aicodinator.backend.global.exception.CustomException;
+import com.aicodinator.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class RegionService {
     private final RegionRepository regionRepository;
+
+    public Region findById(Long regionId) {
+        return regionRepository.findById(regionId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "요청하신 지역을 찾을 수 없습니다."));
+    }
+
+    public List<Region> findMyRegions(User user) {
+        return regionRepository.findRegionsByUser(user);
+    }
 }

--- a/src/main/java/com/aicodinator/backend/domain/report/domain/entity/Report.java
+++ b/src/main/java/com/aicodinator/backend/domain/report/domain/entity/Report.java
@@ -1,6 +1,6 @@
 package com.aicodinator.backend.domain.report.domain.entity;
 
-import com.aicodinator.backend.domain.region.domain.Region;
+import com.aicodinator.backend.domain.region.domain.entity.Region;
 import com.aicodinator.backend.domain.selfcheck.domain.entity.SelfCheck;
 import com.aicodinator.backend.domain.user.domain.entity.User;
 import com.aicodinator.backend.global.entity.BaseEntity;

--- a/src/main/java/com/aicodinator/backend/global/config/AwsS3Config.java
+++ b/src/main/java/com/aicodinator/backend/global/config/AwsS3Config.java
@@ -1,0 +1,30 @@
+package com.aicodinator.backend.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 s3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+            .withCredentials(new AWSStaticCredentialsProvider(credentials))
+            .withRegion(region)
+            .build();
+    }
+}

--- a/src/main/java/com/aicodinator/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/aicodinator/backend/global/config/SecurityConfig.java
@@ -1,20 +1,12 @@
 package com.aicodinator.backend.global.config;
 
-import com.aicodinator.backend.domain.user.service.CustomOAuth2UserService;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import java.util.Collections;
+import com.aicodinator.backend.global.security.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
 
 @Configuration
 @RequiredArgsConstructor

--- a/src/main/java/com/aicodinator/backend/global/config/SwaggerBeanConfig.java
+++ b/src/main/java/com/aicodinator/backend/global/config/SwaggerBeanConfig.java
@@ -1,0 +1,17 @@
+package com.aicodinator.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+
+import java.util.ArrayList;
+
+@Configuration
+public class SwaggerBeanConfig {
+
+    public SwaggerBeanConfig(MappingJackson2HttpMessageConverter converter) {
+        var supportedMediaTypes = new ArrayList<>(converter.getSupportedMediaTypes());
+        supportedMediaTypes.add(new MediaType("application", "octet-stream"));
+        converter.setSupportedMediaTypes(supportedMediaTypes);
+    }
+}

--- a/src/main/java/com/aicodinator/backend/global/exception/CustomException.java
+++ b/src/main/java/com/aicodinator/backend/global/exception/CustomException.java
@@ -5,9 +5,17 @@ import lombok.Getter;
 @Getter
 public class CustomException extends RuntimeException {
   private final ErrorCode errorCode;
+  private final String message;
 
   public CustomException(ErrorCode errorCode){
     super(errorCode.getMessage());
     this.errorCode = errorCode;
+    this.message = null;
+  }
+
+  public CustomException(ErrorCode errorCode, String message) {
+      super(message);
+      this.errorCode = errorCode;
+      this.message = message;
   }
 }

--- a/src/main/java/com/aicodinator/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/aicodinator/backend/global/exception/ErrorCode.java
@@ -7,42 +7,46 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-  /*
-   * 400 BAD_REQUEST: 잘못된 요청
-   */
-  BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    /*
+     * 400 BAD_REQUEST: 잘못된 요청
+     */
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INVALID_FILE_REQUEST(HttpStatus.BAD_REQUEST, "유효하지 않은 파일 요청입니다."),
 
-  /*
-   * 401 UNAUTHORIZED: 인증되지 않은 사용자의 요청
-   */
-  UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
-  INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
-  TOKEN_ALREADY_LOGOUT(HttpStatus.UNAUTHORIZED, "이미 로그아웃된 토큰입니다."),
-  TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
-  INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다."),
-  INCORRECT_CURRENT_PASSWORD(HttpStatus.UNAUTHORIZED, "현재 비밀번호가 일치하지 않습니다."),
+    /*
+     * 401 UNAUTHORIZED: 인증되지 않은 사용자의 요청
+     */
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
+    TOKEN_ALREADY_LOGOUT(HttpStatus.UNAUTHORIZED, "이미 로그아웃된 토큰입니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다."),
+    INCORRECT_CURRENT_PASSWORD(HttpStatus.UNAUTHORIZED, "현재 비밀번호가 일치하지 않습니다."),
 
-  /*
-   * 403 FORBIDDEN: 권한이 없는 사용자의 요청
-   */
-  FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    /*
+     * 403 FORBIDDEN: 권한이 없는 사용자의 요청
+     */
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
-  /*
-   * 404 NOT_FOUND: 리소스를 찾을 수 없음
-   */
-  NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 리소스를 찾을 수 없습니다."),
+    /*
+     * 404 NOT_FOUND: 리소스를 찾을 수 없음
+     */
+    NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 리소스를 찾을 수 없습니다."),
 
-  /*
-   * 405 METHOD_NOT_ALLOWED: 허용되지 않은 Request Method 호출
-   */
-  METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 요청 방식입니다."),
+    /*
+     * 405 METHOD_NOT_ALLOWED: 허용되지 않은 Request Method 호출
+     */
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 요청 방식입니다."),
 
-  /*
-   * 500 INTERNAL_SERVER_ERROR: 내부 서버 오류
-   */
-  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+    /*
+     * 500 INTERNAL_SERVER_ERROR: 내부 서버 오류
+     */
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+    S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 파일 업로드에 실패했습니다."),
+    S3_UPLOAD_AMAZON_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3 에러로 인해 파일 업로드에 실패했습니다."),
+    S3_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 파일 삭제에 실패했습니다."),
+    S3_DELETE_AMAZON_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3 에러로 인해 파일 삭제에 실패했습니다.");
 
-
-  private final HttpStatus httpStatus;
-  private final String message;
+    private final HttpStatus httpStatus;
+    private final String message;
 }

--- a/src/main/java/com/aicodinator/backend/global/exception/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/aicodinator/backend/global/exception/controller/GlobalExceptionHandler.java
@@ -50,7 +50,7 @@ public class GlobalExceptionHandler {
     ErrorCode errorCode = e.getErrorCode();
     ErrorResponse response = ErrorResponse.builder()
         .errorCode(errorCode)
-        .errorMessage(errorCode.getMessage())
+        .errorMessage(e.getMessage() == null ? errorCode.getMessage() : e.getMessage())
         .build();
 
     return ResponseEntity.status(errorCode.getHttpStatus()).body(response);

--- a/src/main/java/com/aicodinator/backend/global/security/CustomOAuth2User.java
+++ b/src/main/java/com/aicodinator/backend/global/security/CustomOAuth2User.java
@@ -1,0 +1,19 @@
+package com.aicodinator.backend.global.security;
+
+import com.aicodinator.backend.domain.user.domain.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+@Getter
+public class CustomOAuth2User extends DefaultOAuth2User {
+    private final User user;
+
+    public CustomOAuth2User(User user, Collection<? extends GrantedAuthority> authorities, Map<String, Object> attributes, String nameAttributeKey) {
+        super(authorities, attributes, nameAttributeKey);
+        this.user = user;
+    }
+}

--- a/src/main/java/com/aicodinator/backend/global/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/aicodinator/backend/global/security/CustomOAuth2UserService.java
@@ -76,8 +76,9 @@ public class CustomOAuth2UserService
                     return userRepository.save(u);
                 });
 
-        // 세션에 저장될 DefaultOAuth2User 반환
-        return new DefaultOAuth2User(
+        // CustomOAuth2User 반환
+        return new CustomOAuth2User(
+                user,
                 Collections.singleton(new SimpleGrantedAuthority("ROLE_" + user.getRole())),
                 attributes,
                 userInfo.getNameAttributeKey()

--- a/src/main/java/com/aicodinator/backend/global/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/aicodinator/backend/global/security/CustomOAuth2UserService.java
@@ -1,4 +1,4 @@
-package com.aicodinator.backend.domain.user.service;
+package com.aicodinator.backend.global.security;
 
 import com.aicodinator.backend.domain.user.domain.constant.Role;
 import com.aicodinator.backend.domain.user.domain.constant.SocialPlatform;


### PR DESCRIPTION
## ✨ 변경 사항
- AI 리포트 생성 시, 지역별 게시판 4종 자동 생성이 가능하도록 게시판 생성 로직 구현
- 특정 지역에 속한 게시판 목록 조회 기능 구현
- 게시글 생성 기능 구현 (S3 파일 업로드 포함)
- 게시글 상세 조회 기능 구현 (파일, 댓글, 좋아요 수 포함)
- 게시판별 게시글 목록 조회 기능 구현 (페이징 처리)
- 지역별 게시판 메인 조회 기능 구현 (최신글, 인기글, 최신댓글이 달린 글, 댓글 많은 글)
- 게시글 수정 기능 구현 (첨부 파일 수정 포함)
- 게시글 삭제 기능 구현 (Hard Delete)
- 게시글 좋아요 기능 구현 (좋아요/취소 토글)
- 댓글 작성 / 수정 / 삭제 구현

## 🔄 연관 이슈
- #6 

## ✅ 체크리스트
- [x] 코드 빌드/테스트 통과
- [x] 문서·주석 업데이트

## 📖 기타
검색은 추후 구현 예정입니다.
